### PR TITLE
Generate Artist resource

### DIFF
--- a/lib/sing_for_needs/artists.ex
+++ b/lib/sing_for_needs/artists.ex
@@ -1,0 +1,104 @@
+defmodule SingForNeeds.Artists do
+  @moduledoc """
+  The Artists context.
+  """
+
+  import Ecto.Query, warn: false
+  alias SingForNeeds.Repo
+
+  alias SingForNeeds.Artists.Artist
+
+  @doc """
+  Returns the list of artists.
+
+  ## Examples
+
+      iex> list_artists()
+      [%Artist{}, ...]
+
+  """
+  def list_artists do
+    Repo.all(Artist)
+  end
+
+  @doc """
+  Gets a single artist.
+
+  Raises `Ecto.NoResultsError` if the Artist does not exist.
+
+  ## Examples
+
+      iex> get_artist!(123)
+      %Artist{}
+
+      iex> get_artist!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_artist!(id), do: Repo.get!(Artist, id)
+
+  @doc """
+  Creates a artist.
+
+  ## Examples
+
+      iex> create_artist(%{field: value})
+      {:ok, %Artist{}}
+
+      iex> create_artist(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_artist(attrs \\ %{}) do
+    %Artist{}
+    |> Artist.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a artist.
+
+  ## Examples
+
+      iex> update_artist(artist, %{field: new_value})
+      {:ok, %Artist{}}
+
+      iex> update_artist(artist, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_artist(%Artist{} = artist, attrs) do
+    artist
+    |> Artist.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a Artist.
+
+  ## Examples
+
+      iex> delete_artist(artist)
+      {:ok, %Artist{}}
+
+      iex> delete_artist(artist)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_artist(%Artist{} = artist) do
+    Repo.delete(artist)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking artist changes.
+
+  ## Examples
+
+      iex> change_artist(artist)
+      %Ecto.Changeset{source: %Artist{}}
+
+  """
+  def change_artist(%Artist{} = artist) do
+    Artist.changeset(artist, %{})
+  end
+end

--- a/lib/sing_for_needs/artists/artist.ex
+++ b/lib/sing_for_needs/artists/artist.ex
@@ -1,0 +1,18 @@
+defmodule SingForNeeds.Artists.Artist do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+
+  schema "artists" do
+    field :name, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(artist, attrs) do
+    artist
+    |> cast(attrs, [:name])
+    |> validate_required([:name])
+  end
+end

--- a/lib/sing_for_needs_web/controllers/artist_controller.ex
+++ b/lib/sing_for_needs_web/controllers/artist_controller.ex
@@ -1,0 +1,43 @@
+defmodule SingForNeedsWeb.ArtistController do
+  use SingForNeedsWeb, :controller
+
+  alias SingForNeeds.Artists
+  alias SingForNeeds.Artists.Artist
+
+  action_fallback SingForNeedsWeb.FallbackController
+
+  def index(conn, _params) do
+    artists = Artists.list_artists()
+    render(conn, "index.json", artists: artists)
+  end
+
+  def create(conn, %{"artist" => artist_params}) do
+    with {:ok, %Artist{} = artist} <- Artists.create_artist(artist_params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", Routes.artist_path(conn, :show, artist))
+      |> render("show.json", artist: artist)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    artist = Artists.get_artist!(id)
+    render(conn, "show.json", artist: artist)
+  end
+
+  def update(conn, %{"id" => id, "artist" => artist_params}) do
+    artist = Artists.get_artist!(id)
+
+    with {:ok, %Artist{} = artist} <- Artists.update_artist(artist, artist_params) do
+      render(conn, "show.json", artist: artist)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    artist = Artists.get_artist!(id)
+
+    with {:ok, %Artist{}} <- Artists.delete_artist(artist) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/sing_for_needs_web/controllers/fallback_controller.ex
+++ b/lib/sing_for_needs_web/controllers/fallback_controller.ex
@@ -1,0 +1,22 @@
+defmodule SingForNeedsWeb.FallbackController do
+  @moduledoc """
+  Translates controller action results into valid `Plug.Conn` responses.
+
+  See `Phoenix.Controller.action_fallback/1` for more details.
+  """
+  use SingForNeedsWeb, :controller
+
+  def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(SingForNeedsWeb.ChangesetView)
+    |> render("error.json", changeset: changeset)
+  end
+
+  def call(conn, {:error, :not_found}) do
+    conn
+    |> put_status(:not_found)
+    |> put_view(SingForNeedsWeb.ErrorView)
+    |> render(:"404")
+  end
+end

--- a/lib/sing_for_needs_web/router.ex
+++ b/lib/sing_for_needs_web/router.ex
@@ -20,7 +20,9 @@ defmodule SingForNeedsWeb.Router do
   end
 
   # Other scopes may use custom stacks.
-  # scope "/api", SingForNeedsWeb do
-  #   pipe_through :api
-  # end
+  scope "/api", SingForNeedsWeb do
+    pipe_through :api
+
+    resources "/artists", ArtistController, except: [:new, :edit]
+  end
 end

--- a/lib/sing_for_needs_web/views/artist_view.ex
+++ b/lib/sing_for_needs_web/views/artist_view.ex
@@ -1,0 +1,17 @@
+defmodule SingForNeedsWeb.ArtistView do
+  use SingForNeedsWeb, :view
+  alias SingForNeedsWeb.ArtistView
+
+  def render("index.json", %{artists: artists}) do
+    %{data: render_many(artists, ArtistView, "artist.json")}
+  end
+
+  def render("show.json", %{artist: artist}) do
+    %{data: render_one(artist, ArtistView, "artist.json")}
+  end
+
+  def render("artist.json", %{artist: artist}) do
+    %{id: artist.id,
+      name: artist.name}
+  end
+end

--- a/lib/sing_for_needs_web/views/changeset_view.ex
+++ b/lib/sing_for_needs_web/views/changeset_view.ex
@@ -1,0 +1,19 @@
+defmodule SingForNeedsWeb.ChangesetView do
+  use SingForNeedsWeb, :view
+
+  @doc """
+  Traverses and translates changeset errors.
+
+  See `Ecto.Changeset.traverse_errors/2` and
+  `SingForNeedsWeb.ErrorHelpers.translate_error/1` for more details.
+  """
+  def translate_errors(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, &translate_error/1)
+  end
+
+  def render("error.json", %{changeset: changeset}) do
+    # When encoded, the changeset returns its errors
+    # as a JSON object. So we just pass it forward.
+    %{errors: translate_errors(changeset)}
+  end
+end

--- a/priv/repo/migrations/20190415201336_create_artists.exs
+++ b/priv/repo/migrations/20190415201336_create_artists.exs
@@ -1,0 +1,12 @@
+defmodule SingForNeeds.Repo.Migrations.CreateArtists do
+  use Ecto.Migration
+
+  def change do
+    create table(:artists) do
+      add :name, :string
+
+      timestamps()
+    end
+
+  end
+end

--- a/test/sing_for_needs/artists/artists_test.exs
+++ b/test/sing_for_needs/artists/artists_test.exs
@@ -1,0 +1,64 @@
+defmodule SingForNeeds.ArtistsTest do
+  use SingForNeeds.DataCase
+
+  alias SingForNeeds.Artists
+
+  describe "artists" do
+    alias SingForNeeds.Artists.Artist
+
+    @valid_attrs %{name: "some name"}
+    @update_attrs %{name: "some updated name"}
+    @invalid_attrs %{name: nil}
+
+    def artist_fixture(attrs \\ %{}) do
+      {:ok, artist} =
+        attrs
+        |> Enum.into(@valid_attrs)
+        |> Artists.create_artist()
+
+      artist
+    end
+
+    test "list_artists/0 returns all artists" do
+      artist = artist_fixture()
+      assert Artists.list_artists() == [artist]
+    end
+
+    test "get_artist!/1 returns the artist with given id" do
+      artist = artist_fixture()
+      assert Artists.get_artist!(artist.id) == artist
+    end
+
+    test "create_artist/1 with valid data creates a artist" do
+      assert {:ok, %Artist{} = artist} = Artists.create_artist(@valid_attrs)
+      assert artist.name == "some name"
+    end
+
+    test "create_artist/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Artists.create_artist(@invalid_attrs)
+    end
+
+    test "update_artist/2 with valid data updates the artist" do
+      artist = artist_fixture()
+      assert {:ok, %Artist{} = artist} = Artists.update_artist(artist, @update_attrs)
+      assert artist.name == "some updated name"
+    end
+
+    test "update_artist/2 with invalid data returns error changeset" do
+      artist = artist_fixture()
+      assert {:error, %Ecto.Changeset{}} = Artists.update_artist(artist, @invalid_attrs)
+      assert artist == Artists.get_artist!(artist.id)
+    end
+
+    test "delete_artist/1 deletes the artist" do
+      artist = artist_fixture()
+      assert {:ok, %Artist{}} = Artists.delete_artist(artist)
+      assert_raise Ecto.NoResultsError, fn -> Artists.get_artist!(artist.id) end
+    end
+
+    test "change_artist/1 returns a artist changeset" do
+      artist = artist_fixture()
+      assert %Ecto.Changeset{} = Artists.change_artist(artist)
+    end
+  end
+end

--- a/test/sing_for_needs_web/controllers/artist_controller_test.exs
+++ b/test/sing_for_needs_web/controllers/artist_controller_test.exs
@@ -1,0 +1,88 @@
+defmodule SingForNeedsWeb.ArtistControllerTest do
+  use SingForNeedsWeb.ConnCase
+
+  alias SingForNeeds.Artists
+  alias SingForNeeds.Artists.Artist
+
+  @create_attrs %{
+    name: "some name"
+  }
+  @update_attrs %{
+    name: "some updated name"
+  }
+  @invalid_attrs %{name: nil}
+
+  def fixture(:artist) do
+    {:ok, artist} = Artists.create_artist(@create_attrs)
+    artist
+  end
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "index" do
+    test "lists all artists", %{conn: conn} do
+      conn = get(conn, Routes.artist_path(conn, :index))
+      assert json_response(conn, 200)["data"] == []
+    end
+  end
+
+  describe "create artist" do
+    test "renders artist when data is valid", %{conn: conn} do
+      conn = post(conn, Routes.artist_path(conn, :create), artist: @create_attrs)
+      assert %{"id" => id} = json_response(conn, 201)["data"]
+
+      conn = get(conn, Routes.artist_path(conn, :show, id))
+
+      assert %{
+               "id" => id,
+               "name" => "some name"
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, Routes.artist_path(conn, :create), artist: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "update artist" do
+    setup [:create_artist]
+
+    test "renders artist when data is valid", %{conn: conn, artist: %Artist{id: id} = artist} do
+      conn = put(conn, Routes.artist_path(conn, :update, artist), artist: @update_attrs)
+      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+
+      conn = get(conn, Routes.artist_path(conn, :show, id))
+
+      assert %{
+               "id" => id,
+               "name" => "some updated name"
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, artist: artist} do
+      conn = put(conn, Routes.artist_path(conn, :update, artist), artist: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "delete artist" do
+    setup [:create_artist]
+
+    test "deletes chosen artist", %{conn: conn, artist: artist} do
+      conn = delete(conn, Routes.artist_path(conn, :delete, artist))
+      assert response(conn, 204)
+
+      assert_error_sent 404, fn ->
+        get(conn, Routes.artist_path(conn, :show, artist))
+      end
+    end
+  end
+
+  defp create_artist(_) do
+    artist = fixture(:artist)
+    {:ok, artist: artist}
+  end
+end

--- a/test/sing_for_needs_web/controllers/artist_controller_test.exs
+++ b/test/sing_for_needs_web/controllers/artist_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule SingForNeedsWeb.ArtistControllerTest do
   use SingForNeedsWeb.ConnCase
 
+  alias SingForNeedsWeb.Router.Helpers, as: Routes
   alias SingForNeeds.Artists
   alias SingForNeeds.Artists.Artist
 

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -1,4 +1,4 @@
-defmodule SingForNeedsTest.DataCase do
+defmodule SingForNeeds.DataCase do
     @moduledoc """
     This module defines the setup for tests requiring
     access to the application's data layer.
@@ -14,12 +14,12 @@ defmodule SingForNeedsTest.DataCase do
 
     using do
       quote do
-        alias SingForNeedsTest.Repo
+        alias SingForNeeds.Repo
 
         import Ecto
         import Ecto.Changeset
         import Ecto.Query
-        import SingForNeedsTest.DataCase
+        import SingForNeeds.DataCase
       end
     end
 

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -15,7 +15,6 @@ defmodule SingForNeeds.DataCase do
     using do
       quote do
         alias SingForNeeds.Repo
-
         import Ecto
         import Ecto.Changeset
         import Ecto.Query
@@ -24,10 +23,10 @@ defmodule SingForNeeds.DataCase do
     end
 
     setup tags do
-      :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+      :ok = Ecto.Adapters.SQL.Sandbox.checkout(SingForNeeds.Repo)
 
        unless tags[:async] do
-        Ecto.Adapters.SQL.Sandbox.mode(Repo, {:shared, self()})
+        Ecto.Adapters.SQL.Sandbox.mode(SingForNeeds.Repo, {:shared, self()})
       end
 
        :ok

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,3 @@
 ExUnit.start()
 
-Ecto.Adapters.SQL.Sandbox.mode(SingForNeeds.Repo, :manual)
+Ecto.Adapters.SQL.Sandbox.mode(SingForNeeds.Repo, {:shared, self()})


### PR DESCRIPTION
Use mix.gen to generate Artist resource
@FedericoEsparza we did nor reference user on the artist schema as we had questions whether its needed or we can just add them as the application grows.
Part of the questions was if the artists are themselves users of the system or data about them is what's accessed by the actual users?

Fixes #14 