### PR TITLE
Remove waffle banner from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Waffle.io - Columns and their card count](https://badge.waffle.io/AgileVentures/sing_for_needs.svg?columns=all)](https://waffle.io/AgileVentures/sing_for_needs)
-
 # Sing For Needs
 
 ## Collaborating - Clone Repo


### PR DESCRIPTION
### What does this PR do?
Removes waffle banner from README




#### Description of Task to be completed?

We are no longer using waffle for issue tracking hence no need to point to it from our readme


#### How should this be manually tested?
View README to see there is no banner




#### What are the relevant Github Issues ?

Fixes #49 

