### PR TITLE
Add option to use port number as enviromnet variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ source .env
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
 
+- If another application is already running in your port 4000, you can set your port dynamically by adding it to the .env file, for example, if you want your application to run on port 5000, you can add the following to your .env
+    ```export PORT=5000```
+- Reload the .env by running `source .env` in your terminal
+- Run the server using command `mix phx.server` and access the app using [`localhost:5000`](http://localhost:5000) 
+
 Now you are fully set up and can join us as a collaborator :smile:
 
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ source .env
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
 
-- If another application is already running in your port 4000, you can set your port dynamically by adding it to the .env file, for example, if you want your application to run on port 5000, you can add the following to your .env
+- If you get an error that another application is already running in your port 4000, you can set your port dynamically by adding it to the .env file, for example, if you want your application to run on port 5000, you can add the following to your .env
     ```export PORT=5000```
 - Reload the .env by running `source .env` in your terminal
 - Run the server using command `mix phx.server` and access the app using [`localhost:5000`](http://localhost:5000) 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -7,7 +7,7 @@ use Mix.Config
 # watchers to your application. For example, we use it
 # with webpack to recompile .js and .css sources.
 config :sing_for_needs, SingForNeedsWeb.Endpoint,
-  http: [port: 4000],
+  http: [port: System.get_env("PORT") || 4000],
   debug_errors: true,
   code_reloader: true,
   check_origin: false,


### PR DESCRIPTION
### What does this PR do?

Add an option to set the PORT number as an environmental variable




#### How should this be manually tested?
1. Add `export PORT=6000` to your .env file, 
2. Reload the env variables using `source .env`
3. Run `mix phx.server`
4. On your browser access localhost:4000



#### Any background context you want to provide?

Enables developers to set the application port number dynamically, incase their PORT 4000 is already in use


#### What are the relevant Github Issues ?

FIxes #62 

