### PR TITLE
Remove reference to done and unneeded s in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Ensure that you have a stable version of docker on your machine
 
 Sing For Needs utilises **_Zenhub.com_** for project management, mainly because it's easier to use and it enables the developers/collaborators to cooperate efficiently
 
-Head over and check out the [Sing For Needs's Zenhub Board](https://app.zenhub.com/workspaces/sing-for-needs-5c8d188a534a9b0a86cdc451/board?repos=108547295)
+Head over and check out the [Sing For Needs' Zenhub Board](https://app.zenhub.com/workspaces/sing-for-needs-5c8d188a534a9b0a86cdc451/board?repos=108547295)
 
 The zenhub board is divided into six main pipelines
 
@@ -144,7 +144,7 @@ The zenhub board is divided into six main pipelines
 3. Backlog
 4. In Progress
 5. Review
-6. Done & Closed
+6. Closed
 
 <img width="1064" alt="Screenshot 2019-04-06 06 34 24" src="https://user-images.githubusercontent.com/11988089/55668942-6ce5f980-5836-11e9-8e0b-3d1d5cef3837.png">
 


### PR DESCRIPTION
Remove reference to done and unneeded s in README
Fast doc edit. No related issue.

We're currently not using the **Done** pipeline, mainly because Zenhub automatically moves the merged issues and PRs to the Closed columns (Waffle would move them to a Done column).

I removed the Done pipeline last week, as it was obstructing real estate, in between the Review and Closed column.

We can have a separate conversation about creating a Done or Finished pipeline.