### PR TITLE
Add create mutations from artist

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,7 +1,5 @@
-require Ecto.Query
 alias SingForNeeds.Artists
 alias SingForNeeds.Artists.Artist
 alias SingForNeeds.Causes
 alias SingForNeeds.Causes.Cause
 alias SingForNeeds.Repo
-alias Ecto.Query

--- a/lib/sing_for_needs/artists/artist.ex
+++ b/lib/sing_for_needs/artists/artist.ex
@@ -2,21 +2,44 @@ defmodule SingForNeeds.Artists.Artist do
   @moduledoc false
   use Ecto.Schema
   import Ecto.Changeset
+  alias SingForNeeds.Causes
   alias SingForNeeds.Causes.Cause
   alias SingForNeeds.Performances.Performance
 
   schema "artists" do
     field :name, :string
     field :bio, :string
-    many_to_many(:performances, Performance, join_through: "artists_performances", on_replace: :delete)
+
+    many_to_many(:performances, Performance,
+      join_through: "artists_performances",
+      on_replace: :delete
+    )
+
     many_to_many :causes, Cause, join_through: "artists_causes"
     timestamps()
   end
 
   @doc false
   def changeset(artist, attrs) do
-    artist
-    |> cast(attrs, [:name, :bio])
-    |> validate_required([:name, :bio])
+    artist =
+      artist
+      |> cast(attrs, [:name, :bio])
+      |> validate_required([:name, :bio])
+      |> associate_artist_to_causes(attrs)
+  end
+
+  defp associate_artist_to_causes(artist, attrs) do
+    case attrs do
+      %{causes: causes} ->
+        artist =
+          Ecto.Changeset.put_assoc(
+            artist,
+            :causes,
+            Enum.map(causes, fn cause_id -> Causes.get_cause!(cause_id) end)
+          )
+
+      _ ->
+        artist
+    end
   end
 end

--- a/lib/sing_for_needs_web/resolvers/artists.ex
+++ b/lib/sing_for_needs_web/resolvers/artists.ex
@@ -6,13 +6,4 @@ defmodule SingForNeedsWeb.Resolvers.Artist do
   def artists(_parent, _args, _resolution) do
     {:ok, Artists.list_artists()}
   end
-
-  def artists_for_cause(cause, criteria, %{context: %{loader: loader}}) do
-    loader
-    |> Dataloader.load_many(Artists, {:artists, criteria}, cause)
-    |> on_load(fn loader ->
-      artists = Dataloader.get_many(loader, Artists, {:artists, criteria}, cause)
-      {:ok, artists}
-    end)
-  end
 end

--- a/lib/sing_for_needs_web/resolvers/artists.ex
+++ b/lib/sing_for_needs_web/resolvers/artists.ex
@@ -1,9 +1,12 @@
 defmodule SingForNeedsWeb.Resolvers.Artist do
   @moduledoc false
   alias SingForNeeds.Artists
-  import Absinthe.Resolution.Helpers, only: [on_load: 2]
 
   def artists(_parent, _args, _resolution) do
     {:ok, Artists.list_artists()}
+  end
+
+  def create_artist(_parent, args, _resolution) do
+    Artists.create_artist(args)
   end
 end

--- a/lib/sing_for_needs_web/resolvers/causes.ex
+++ b/lib/sing_for_needs_web/resolvers/causes.ex
@@ -24,16 +24,4 @@ defmodule SingForNeedsWeb.Resolvers.Cause do
         {:ok, cause}
     end
   end
-
-  @doc """
-  artist_for_cause/3 gets a list of artist for each cause
-  """
-  def artists_for_cause(cause, _, %{context: %{loader: loader}}) do
-    loader
-    |> Dataloader.load_many(Causes, :causes, cause)
-    |> on_load(fn loader ->
-      artists = Dataloader.get_many(loader, Causes, :artists, cause)
-      {:ok, artists}
-    end)
-  end
 end

--- a/lib/sing_for_needs_web/schema/artist_types.ex
+++ b/lib/sing_for_needs_web/schema/artist_types.ex
@@ -9,6 +9,7 @@ defmodule SingForNeedsWeb.Schema.ArtistTypes do
   object :artist do
     field :id, :id
     field :name, :string
+    field :bio, :string
     field :causes, list_of(:cause), resolve: dataloader(Causes)
   end
 end

--- a/lib/sing_for_needs_web/schema/schema.ex
+++ b/lib/sing_for_needs_web/schema/schema.ex
@@ -55,5 +55,15 @@ defmodule SingForNeedsWeb.Schema.Schema do
       arg(:artists, list_of(:id))
       resolve(&Cause.create_cause/3)
     end
+
+    @doc """
+    create artists
+    """
+    field :create_artist, :artist do
+      arg(:name, non_null(:string))
+      arg(:bio, non_null(:string))
+      arg(:causes, list_of(:id))
+      resolve(&Artist.create_artist/3)
+    end
   end
 end

--- a/test/sing_for_needs/artists/artists_test.exs
+++ b/test/sing_for_needs/artists/artists_test.exs
@@ -2,7 +2,7 @@ defmodule SingForNeeds.ArtistsTest do
   @moduledoc false
   use SingForNeeds.DataCase
   import SingForNeeds.Factory
-  alias SingForNeeds.Artists
+  alias SingForNeeds.{Artists, Causes}
 
   describe "artists" do
     alias SingForNeeds.Artists.Artist
@@ -41,10 +41,15 @@ defmodule SingForNeeds.ArtistsTest do
     end
 
     test "create_artist/1 creates an artist with cause if cause is in attrs" do
-      causes = insert_list(:cause, 4)
-      require IEx; IEx.pry
-      valid_attrs = Map.put(@valid_attrs, :causes, causes)
-      valid_attrs
+      insert_list(4, :cause)
+      causes = Causes.list_causes()
+      valid_attrs = Map.put(@valid_attrs, :causes, Enum.map(causes, fn cause -> cause.id end))
+
+      assert {:ok, %Artist{causes: associated_causes} = artist} =
+               Artists.create_artist(valid_attrs)
+
+      assert associated_causes == causes
+      assert artist.name == valid_attrs.name
     end
 
     test "update_artist/2 with valid data updates the artist" do

--- a/test/sing_for_needs/artists/artists_test.exs
+++ b/test/sing_for_needs/artists/artists_test.exs
@@ -1,7 +1,7 @@
 defmodule SingForNeeds.ArtistsTest do
   @moduledoc false
   use SingForNeeds.DataCase
-
+  import SingForNeeds.Factory
   alias SingForNeeds.Artists
 
   describe "artists" do
@@ -21,7 +21,6 @@ defmodule SingForNeeds.ArtistsTest do
     end
 
     test "list_artists/0 returns all artists" do
-      import SingForNeeds.Factory
       artist = insert(:artist)
       assert Artists.list_artists() == [artist]
     end
@@ -39,6 +38,13 @@ defmodule SingForNeeds.ArtistsTest do
 
     test "create_artist/1 with invalid data returns error changeset" do
       assert {:error, %Ecto.Changeset{}} = Artists.create_artist(@invalid_attrs)
+    end
+
+    test "create_artist/1 creates an artist with cause if cause is in attrs" do
+      causes = insert_list(:cause, 4)
+      require IEx; IEx.pry
+      valid_attrs = Map.put(@valid_attrs, :causes, causes)
+      valid_attrs
     end
 
     test "update_artist/2 with valid data updates the artist" do

--- a/test/sing_for_needs_web/schema/mutation/artists_test.exs
+++ b/test/sing_for_needs_web/schema/mutation/artists_test.exs
@@ -23,12 +23,23 @@ defmodule SingForNeedsWeb.Schema.Mutation.ArtistsTest do
     cause = insert(:cause)
 
     input = %{
-      name: "Lebron James",
+      name: "Lebron Jamess",
       bio: "Greatest basketball player",
       causes: [cause.id]
     }
 
+    expected_result = %{
+      "data" => %{
+        "createArtist" => %{
+          "bio" => "Greatest basketball player",
+          "causes" => [%{"id" => "1", "name" => "Awesome cause 0"}],
+          "id" => "1",
+          "name" => "Lebron Jamess"
+        }
+      }
+    }
+
     conn = post conn, "/api", query: @create_artist_mutation, variables: input
-    assert input = json_response(conn, 200)
+    assert expected_result == json_response(conn, 200)
   end
 end

--- a/test/sing_for_needs_web/schema/mutation/artists_test.exs
+++ b/test/sing_for_needs_web/schema/mutation/artists_test.exs
@@ -1,0 +1,34 @@
+defmodule SingForNeedsWeb.Schema.Mutation.ArtistsTest do
+  @moduledoc """
+  Contains all tests for artists mutations
+  """
+  use SingForNeedsWeb.ConnCase, async: true
+  import SingForNeeds.Factory
+
+  @create_artist_mutation """
+    mutation($name: String!, $bio: String!, $causes: [ID]!) {
+      createArtist(name: $name, bio: $bio, causes: $causes) {
+        id
+        name
+        causes{
+          name
+          id
+        }
+        bio
+      }
+    }
+  """
+  test "create_artists/1 resolver creates an Artist" do
+    conn = build_conn()
+    cause = insert(:cause)
+
+    input = %{
+      name: "Lebron James",
+      bio: "Greatest basketball player",
+      causes: [cause.id]
+    }
+
+    conn = post conn, "/api", query: @create_artist_mutation, variables: input
+    assert json_response(conn, 200) == input
+  end
+end

--- a/test/sing_for_needs_web/schema/mutation/artists_test.exs
+++ b/test/sing_for_needs_web/schema/mutation/artists_test.exs
@@ -6,7 +6,7 @@ defmodule SingForNeedsWeb.Schema.Mutation.ArtistsTest do
   import SingForNeeds.Factory
 
   @create_artist_mutation """
-    mutation($name: String!, $bio: String!, $causes: [ID]!) {
+    mutation($name: String!, $bio: String!, $causes: [ID]) {
       createArtist(name: $name, bio: $bio, causes: $causes) {
         id
         name
@@ -29,6 +29,6 @@ defmodule SingForNeedsWeb.Schema.Mutation.ArtistsTest do
     }
 
     conn = post conn, "/api", query: @create_artist_mutation, variables: input
-    assert json_response(conn, 200) == input
+    assert input = json_response(conn, 200)
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -6,17 +6,23 @@ defmodule SingForNeeds.Factory do
   use ExMachina.Ecto, repo: SingForNeeds.Repo
 
   alias SingForNeeds.Artists.Artist
+  alias SingForNeeds.Causes.Cause
 
   @doc """
   artist_factory/0 generates factories for for Artist object
-
-  ## Example
-  iex> artist_factory()
   """
   @spec artist_factory :: SingForNeeds.Artists.Artist.t()
   def artist_factory do
     %Artist{
       name: sequence(:name, &"Awesome User #{&1}")
+    }
+  end
+
+  def cause_factory do
+    %Cause{
+      name: sequence(:name, &"Awesome cause #{&1}"),
+      description: sequence(:name, &"Awesome cause description #{&1}"),
+      start_date: ~D[2019-06-07]
     }
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -21,7 +21,7 @@ defmodule SingForNeeds.Factory do
   def cause_factory do
     %Cause{
       name: sequence(:name, &"Awesome cause #{&1}"),
-      description: sequence(:name, &"Awesome cause description #{&1}"),
+      description: sequence(:name, &"Awesome cause #{&1} Description"),
       start_date: ~D[2019-06-07]
     }
   end


### PR DESCRIPTION
### What does this PR do?
Add create artist mutation so that artists can be created by sending a mutation query and variables to the api endpoint

#### What are the relevant Github Issues ?
Fixes #89 