### PR TITLE
Add update artist mutation

### DIFF
--- a/lib/sing_for_needs/artists.ex
+++ b/lib/sing_for_needs/artists.ex
@@ -52,6 +52,24 @@ defmodule SingForNeeds.Artists do
   def get_artist!(id), do: Repo.get!(Artist, id)
 
   @doc """
+  Get a single artist
+
+  Does not raise an Ecto.NoResultsError if record is missing
+
+  ## Examples 
+
+  iex> get_artist(123)
+    %Artist{}
+
+  iex> get_artist(456)
+
+  """
+
+  def get_artist(id) do
+    Repo.get(Artist, id)
+  end
+
+  @doc """
   Creates a artist.
 
   ## Examples

--- a/lib/sing_for_needs_web/resolvers/artists.ex
+++ b/lib/sing_for_needs_web/resolvers/artists.ex
@@ -9,4 +9,8 @@ defmodule SingForNeedsWeb.Resolvers.Artist do
   def create_artist(_parent, args, _resolution) do
     Artists.create_artist(args)
   end
+
+  def update_artist(_parent, args, _resolution) do
+    {:ok, Artists.update_artist(args)}
+  end
 end

--- a/lib/sing_for_needs_web/resolvers/artists.ex
+++ b/lib/sing_for_needs_web/resolvers/artists.ex
@@ -11,6 +11,12 @@ defmodule SingForNeedsWeb.Resolvers.Artist do
   end
 
   def update_artist(_parent, args, _resolution) do
-    {:ok, Artists.update_artist(args)}
+    artist = Artists.get_artist(args[:artist_id])
+
+    if artist do
+      Artists.update_artist(artist, args)
+    else
+      {:error, "Record with id #{args[:artist_id]} missing in database"}
+    end
   end
 end

--- a/lib/sing_for_needs_web/schema/schema.ex
+++ b/lib/sing_for_needs_web/schema/schema.ex
@@ -66,5 +66,15 @@ defmodule SingForNeedsWeb.Schema.Schema do
       arg(:causes, list_of(:id))
       resolve(&Artist.create_artist/3)
     end
+
+    @doc """
+    update_artist
+    """
+    field :update_artist, :artist do
+      arg(:artist_id, non_null(:id))
+      arg(:name, :string)
+      arg(:bio, :string)
+      resolve(&Artist.update_artist/3)
+    end
   end
 end

--- a/test/sing_for_needs/artists/artists_test.exs
+++ b/test/sing_for_needs/artists/artists_test.exs
@@ -25,6 +25,16 @@ defmodule SingForNeeds.ArtistsTest do
       assert Artists.list_artists() == [artist]
     end
 
+    test "get_artist/1 returns an %Artist{} if the artist exists" do
+      artist = insert(:artist)
+      assert artist == Artists.get_artist(artist.id)
+    end
+
+    test "get_artist/1 returns nil if not found" do
+      artist = insert(:artist)
+      assert Artists.get_artist(artist.id + 10_000) == nil
+    end
+
     test "get_artist!/1 returns the artist with given id" do
       artist = artist_fixture()
       assert Artists.get_artist!(artist.id) == artist

--- a/test/sing_for_needs_web/schema/mutation/artists_test.exs
+++ b/test/sing_for_needs_web/schema/mutation/artists_test.exs
@@ -18,7 +18,7 @@ defmodule SingForNeedsWeb.Schema.Mutation.ArtistsTest do
   """
   @update_artist_mutation """
     mutation($artistId: ID!, $name: String, $bio: String) {
-      updateArtist(artistID: $artist_id, name: $name, bio: $bio) {
+      updateArtist(artistId: $artistId, name: $name, bio: $bio) {
         name
         bio
       }
@@ -46,5 +46,18 @@ defmodule SingForNeedsWeb.Schema.Mutation.ArtistsTest do
 
     conn = post conn, "/api", query: @create_artist_mutation, variables: input
     assert expected_result == json_response(conn, 200)
+  end
+
+  test "update_artist/1 updates an artist" do
+    conn = build_conn()
+    artist = insert(:artist)
+    input = %{
+      artistId: artist.id,
+      name: "Stephen Curry",
+      bio: "Cheff curry with the pot"
+    }
+
+    conn = post conn, "/api", query: @update_artist_mutation, variables: input
+    assert input == json_response(conn, 200)
   end
 end

--- a/test/sing_for_needs_web/schema/mutation/artists_test.exs
+++ b/test/sing_for_needs_web/schema/mutation/artists_test.exs
@@ -10,8 +10,16 @@ defmodule SingForNeedsWeb.Schema.Mutation.ArtistsTest do
       createArtist(name: $name, bio: $bio, causes: $causes) {
         name
         causes{
-          name
+          startDate
         }
+        bio
+      }
+    }
+  """
+  @update_artist_mutation """
+    mutation($artistId: ID!, $name: String, $bio: String) {
+      updateArtist(artistID: $artist_id, name: $name, bio: $bio) {
+        name
         bio
       }
     }
@@ -30,7 +38,7 @@ defmodule SingForNeedsWeb.Schema.Mutation.ArtistsTest do
       "data" => %{
         "createArtist" => %{
           "bio" => "Greatest basketball player",
-          "causes" => [%{"name" => "Awesome cause 0"}],
+          "causes" => [%{"startDate" => "2019-06-07"}],
           "name" => "Lebron James"
         }
       }

--- a/test/sing_for_needs_web/schema/mutation/artists_test.exs
+++ b/test/sing_for_needs_web/schema/mutation/artists_test.exs
@@ -51,13 +51,45 @@ defmodule SingForNeedsWeb.Schema.Mutation.ArtistsTest do
   test "update_artist/1 updates an artist" do
     conn = build_conn()
     artist = insert(:artist)
+
     input = %{
       artistId: artist.id,
       name: "Stephen Curry",
       bio: "Cheff curry with the pot"
     }
 
+    expected_result = %{
+      "data" => %{
+        "updateArtist" => %{"bio" => "Cheff curry with the pot", "name" => "Stephen Curry"}
+      }
+    }
+
     conn = post conn, "/api", query: @update_artist_mutation, variables: input
-    assert input == json_response(conn, 200)
+    assert expected_result == json_response(conn, 200)
+  end
+
+  test "update artists for missing artist returns an error" do
+    conn = build_conn()
+    artist = insert(:artist)
+
+    input = %{
+      artistId: artist.id + 10_009_999,
+      name: "Stephen Curry",
+      bio: "Cheff curry with the pot"
+    }
+
+    expected_result = %{
+      "data" => %{"updateArtist" => nil},
+      "errors" => [
+        %{
+          "locations" => [%{"column" => 0, "line" => 2}],
+          "message" => "Record with id #{artist.id + 10_009_999} missing in database",
+          "path" => ["updateArtist"]
+        }
+      ]
+    }
+
+    conn = post conn, "/api", query: @update_artist_mutation, variables: input
+    assert expected_result == json_response(conn, 200)
   end
 end


### PR DESCRIPTION
### What does this PR do?

- Adds update mutation for artists, updates an artist if he/she already exists
- Returns a descriptive error message if the artist does not exist




#### What are the relevant Github Issues ?
Fixes #114 
