### PR TITLE
Implement trending causes and causes ending soon

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,3 +1,4 @@
+use Timex
 alias SingForNeeds.Artists
 alias SingForNeeds.Artists.Artist
 alias SingForNeeds.Causes

--- a/lib/sing_for_needs/causes.ex
+++ b/lib/sing_for_needs/causes.ex
@@ -46,6 +46,13 @@ defmodule SingForNeeds.Causes do
     limit(Cause, ^limit)
   end
 
+  defp causes_query(%{scope: scope}) do
+    case scope do
+      "trending" ->
+        Cause |> order_by(desc: :amount_raised)
+    end
+  end
+
   defp causes_query(criteria) do
     Enum.reduce(criteria, Cause, fn
       {:order, order}, query ->

--- a/lib/sing_for_needs/causes.ex
+++ b/lib/sing_for_needs/causes.ex
@@ -50,11 +50,10 @@ defmodule SingForNeeds.Causes do
   defp causes_query(%{scope: scope}) do
     case scope do
       "trending" ->
-        Cause |> order_by(desc: :amount_raised)
+        order_by(Cause, desc: :amount_raised)
 
       "ending_soon" ->
-        query =
-          from(c in Cause,
+        from(c in Cause,
             where: c.end_date > ^Timex.now(),
             order_by: [asc: c.end_date],
             select: c

--- a/lib/sing_for_needs/causes.ex
+++ b/lib/sing_for_needs/causes.ex
@@ -53,10 +53,12 @@ defmodule SingForNeeds.Causes do
         Cause |> order_by(desc: :amount_raised)
 
       "ending_soon" ->
-        query = from(c in Cause,
-                where: c.end_date > ^Timex.now,
-                order_by: [asc: c.end_date],
-                select: c)
+        query =
+          from(c in Cause,
+            where: c.end_date > ^Timex.now(),
+            order_by: [asc: c.end_date],
+            select: c
+          )
     end
   end
 

--- a/lib/sing_for_needs/causes.ex
+++ b/lib/sing_for_needs/causes.ex
@@ -50,14 +50,20 @@ defmodule SingForNeeds.Causes do
   defp causes_query(%{scope: scope}) do
     case scope do
       "trending" ->
-        order_by(Cause, desc: :amount_raised)
+        from(c in Cause,
+          left_join: a in assoc(c, :artists),
+          preload: [:artists],
+          order_by: [desc: :amount_raised, desc: count(a.id)],
+          group_by: c.id,
+          select: c
+        )
 
       "ending_soon" ->
         from(c in Cause,
-            where: c.end_date > ^Timex.now(),
-            order_by: [asc: c.end_date],
-            select: c
-          )
+          where: c.end_date > ^Timex.now(),
+          order_by: [asc: c.end_date],
+          select: c
+        )
     end
   end
 

--- a/lib/sing_for_needs/causes.ex
+++ b/lib/sing_for_needs/causes.ex
@@ -4,6 +4,7 @@ defmodule SingForNeeds.Causes do
   """
 
   import Ecto.Query, warn: false
+  use Timex
   alias SingForNeeds.Repo
 
   alias SingForNeeds.Causes.Cause
@@ -52,7 +53,10 @@ defmodule SingForNeeds.Causes do
         Cause |> order_by(desc: :amount_raised)
 
       "ending_soon" ->
-        Cause |> order_by(asc: :end_date)
+        query = from(c in Cause,
+                where: c.end_date > ^Timex.now,
+                order_by: [asc: c.end_date],
+                select: c)
     end
   end
 

--- a/lib/sing_for_needs/causes.ex
+++ b/lib/sing_for_needs/causes.ex
@@ -50,6 +50,9 @@ defmodule SingForNeeds.Causes do
     case scope do
       "trending" ->
         Cause |> order_by(desc: :amount_raised)
+
+      "ending_soon" ->
+        Cause |> order_by(asc: :end_date)
     end
   end
 

--- a/lib/sing_for_needs_web/schema/schema.ex
+++ b/lib/sing_for_needs_web/schema/schema.ex
@@ -32,6 +32,7 @@ defmodule SingForNeedsWeb.Schema.Schema do
     @desc "get list of all causes"
     field :causes, list_of(:cause) do
       arg(:limit, :integer)
+      arg(:scope, :string)
       resolve(&Cause.causes/3)
     end
 

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule SingForNeeds.MixProject do
   def application do
     [
       mod: {SingForNeeds.Application, []},
-      extra_applications: [:logger, :runtime_tools]
+      extra_applications: [:logger, :runtime_tools, :timex]
     ]
   end
 
@@ -58,7 +58,8 @@ defmodule SingForNeeds.MixProject do
       {:dataloader, "~> 1.0.0"},
       {:distillery, "~> 2.0", runtime: false},
       {:ex_machina, "~> 2.3", only: :test},
-      {:excoveralls, "~> 0.10", only: :test}
+      {:excoveralls, "~> 0.10", only: :test},
+      {:timex, "~> 3.5"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -5,6 +5,7 @@
   "artificery": {:hex, :artificery, "0.4.2", "3ded6e29e13113af52811c72f414d1e88f711410cac1b619ab3a2666bbd7efd4", [:mix], [], "hexpm"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
+  "combine": {:hex, :combine, "0.10.0", "eff8224eeb56498a2af13011d142c5e7997a80c8f5b97c499f84c841032e429f", [:mix], [], "hexpm"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
   "cors_plug": {:hex, :cors_plug, "1.5.2", "72df63c87e4f94112f458ce9d25800900cc88608c1078f0e4faddf20933eda6e", [:mix], [{:plug, "~> 1.3 or ~> 1.4 or ~> 1.5", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "cowboy": {:hex, :cowboy, "2.7.0", "91ed100138a764355f43316b1d23d7ff6bdb0de4ea618cb5d8677c93a7a2f115", [:rebar3], [{:cowlib, "~> 2.8.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.7.1", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
@@ -39,5 +40,7 @@
   "ranch": {:hex, :ranch, "1.7.1", "6b1fab51b49196860b733a49c07604465a47bdb78aa10c1c16a3d199f7f8c881", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.5", "6eaf7ad16cb568bb01753dbbd7a95ff8b91c7979482b95f38443fe2c8852a79b", [:make, :mix, :rebar3], [], "hexpm"},
   "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
+  "timex": {:hex, :timex, "3.6.1", "efdf56d0e67a6b956cc57774353b0329c8ab7726766a11547e529357ffdc1d56", [:mix], [{:combine, "~> 0.10", [hex: :combine, repo: "hexpm", optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, repo: "hexpm", optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5 or ~> 1.0.0", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
+  "tzdata": {:hex, :tzdata, "1.0.2", "6c4242c93332b8590a7979eaf5e11e77d971e579805c44931207e32aa6ad3db1", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
 }

--- a/test/sing_for_needs_web/schema/query/causes_test.exs
+++ b/test/sing_for_needs_web/schema/query/causes_test.exs
@@ -5,16 +5,6 @@ defmodule SingForNeeds.Schema.Query.CauseTest do
   use SingForNeedsWeb.ConnCase, async: true
   import SingForNeeds.Factory
 
-  @query_with_args """
-    query($limit: Int) {
-        causes(limit: $limit) {
-            startDate
-            artists {
-              name
-            }
-        }
-    }
-  """
   @query """
     query {
         causes {
@@ -35,37 +25,78 @@ defmodule SingForNeeds.Schema.Query.CauseTest do
     conn = build_conn()
     conn = get conn, "/api", query: @query
 
-    assert %{
-             "data" => %{
-               "causes" => [
-                 %{
-                   "name" => "Awesome cause 0",
-                   "artists" => [%{"name" => "Artist 1"}, %{"name" => "Artist 2"}]
-                 },
-                 %{
-                   "name" => "Awesome cause 1",
-                   "artists" => [
-                     %{"name" => "Artist 1"},
-                     %{"name" => "Artist 2"},
-                     %{"name" => "Artist 3"}
-                   ]
-                 },
-                 %{"name" => "Awesome cause 2", "artists" => [%{"name" => "Artist 1"}]}
-               ]
-             }
-           } = json_response(conn, 200)
+    expected_result = %{
+      "data" => %{
+        "causes" => [
+          %{
+            "name" => "Awesome cause 0",
+            "artists" => [%{"name" => "Artist 1"}, %{"name" => "Artist 2"}]
+          },
+          %{
+            "name" => "Awesome cause 1",
+            "artists" => [
+              %{"name" => "Artist 1"},
+              %{"name" => "Artist 2"},
+              %{"name" => "Artist 3"}
+            ]
+          },
+          %{"name" => "Awesome cause 2", "artists" => [%{"name" => "Artist 1"}]}
+        ]
+      }
+    }
+
+    assert expected_result = json_response(conn, 200)
   end
 
   test "causes query can filter causes with limit" do
+    causes_limit_query = """
+      query($limit: Int, $scope: String) {
+          causes(limit: $limit, scope: $scope) {
+              startDate
+              artists {
+                name
+              }
+          }
+      }
+    """
+
     insert_list(5, :cause)
     conn = build_conn()
-    conn = post conn, "/api", query: @query_with_args, variables: %{limit: 2}
+    conn = post conn, "/api", query: causes_limit_query, variables: %{limit: 2}
 
     expected_result = %{
       "data" => %{
         "causes" => [
           %{"artists" => [], "startDate" => "2019-06-07"},
           %{"artists" => [], "startDate" => "2019-06-07"}
+        ]
+      }
+    }
+
+    assert expected_result == json_response(conn, 200)
+  end
+
+  test "trending causes are ordered by most amount donated" do
+    trending_causes_query = """
+      query($limit: Int, $scope: String) {
+          causes(limit: $limit, scope: $scope) {
+              name
+          }
+      }
+    """
+
+    insert(:cause, %{name: "Cause with Medium Donation", amount_raised: 30_000})
+    insert(:cause, %{name: "Cause with Least Donation", amount_raised: 10_000})
+    insert(:cause, %{name: "Cause with Highest Donation", amount_raised: 90_000})
+    conn = build_conn()
+    conn = post conn, "/api", query: trending_causes_query, variables: %{scope: "trending"}
+
+    expected_result = %{
+      "data" => %{
+        "causes" => [
+          %{"name" => "Cause with Highest Donation"},
+          %{"name" => "Cause with Medium Donation"},
+          %{"name" => "Cause with Least Donation"}
         ]
       }
     }

--- a/test/sing_for_needs_web/schema/query/causes_test.exs
+++ b/test/sing_for_needs_web/schema/query/causes_test.exs
@@ -8,7 +8,6 @@ defmodule SingForNeeds.Schema.Query.CauseTest do
   @query """
     query {
         causes {
-            id
             name
             artists {
               name
@@ -45,7 +44,7 @@ defmodule SingForNeeds.Schema.Query.CauseTest do
       }
     }
 
-    assert expected_result = json_response(conn, 200)
+    assert expected_result == json_response(conn, 200)
   end
 
   test "causes query can filter causes with limit" do

--- a/test/sing_for_needs_web/schema/query/causes_test.exs
+++ b/test/sing_for_needs_web/schema/query/causes_test.exs
@@ -103,4 +103,32 @@ defmodule SingForNeeds.Schema.Query.CauseTest do
 
     assert expected_result == json_response(conn, 200)
   end
+
+  test "causes ending soon are ordered from the nearest end date" do
+    causes_ending_soon_query = """
+      query($scope: String) {
+          causes(scope: $scope) {
+              name
+          }
+      }
+    """
+
+    insert(:cause, %{name: "Cause ends second", end_date: ~D[2019-12-11]})
+    insert(:cause, %{name: "Cause ends third", end_date: ~D[2020-01-01]})
+    insert(:cause, %{name: "Cause ends first", end_date: ~D[2019-12-01]})
+    conn = build_conn()
+    conn = post conn, "/api", query: causes_ending_soon_query, variables: %{scope: "ending_soon"}
+
+    expected_result = %{
+      "data" => %{
+        "causes" => [
+          %{"name" => "Cause ends first"},
+          %{"name" => "Cause ends second"},
+          %{"name" => "Cause ends third"}
+        ]
+      }
+    }
+
+    assert expected_result == json_response(conn, 200)
+  end
 end

--- a/test/sing_for_needs_web/schema/query/causes_test.exs
+++ b/test/sing_for_needs_web/schema/query/causes_test.exs
@@ -85,9 +85,24 @@ defmodule SingForNeeds.Schema.Query.CauseTest do
       }
     """
 
-    insert(:cause, %{name: "Cause with Medium Donation", amount_raised: 30_000})
+    artists = insert_list(4, :artist)
+
+    insert(:cause, %{
+      name: "Cause with Medium Donation",
+      amount_raised: 30_000,
+      artists: Enum.take(artists, 2)
+    })
+
     insert(:cause, %{name: "Cause with Least Donation", amount_raised: 10_000})
-    insert(:cause, %{name: "Cause with Highest Donation", amount_raised: 90_000})
+
+    insert(:cause, %{
+      name: "Cause with Least Donation and two artists",
+      amount_raised: 10_000,
+      artists: Enum.take(artists, -2)
+    })
+
+    insert(:cause, %{name: "Cause with Highest Donation", amount_raised: 90_000, artists: artists})
+
     conn = build_conn()
     conn = post conn, "/api", query: trending_causes_query, variables: %{scope: "trending"}
 
@@ -96,6 +111,7 @@ defmodule SingForNeeds.Schema.Query.CauseTest do
         "causes" => [
           %{"name" => "Cause with Highest Donation"},
           %{"name" => "Cause with Medium Donation"},
+          %{"name" => "Cause with Least Donation and two artists"},
           %{"name" => "Cause with Least Donation"}
         ]
       }

--- a/test/sing_for_needs_web/schema/query/causes_test.exs
+++ b/test/sing_for_needs_web/schema/query/causes_test.exs
@@ -2,6 +2,7 @@ defmodule SingForNeeds.Schema.Query.CauseTest do
   @moduledoc """
   Test all the queries for Cause schema
   """
+  use Timex
   use SingForNeedsWeb.ConnCase, async: true
   import SingForNeeds.Factory
 
@@ -112,18 +113,21 @@ defmodule SingForNeeds.Schema.Query.CauseTest do
       }
     """
 
-    insert(:cause, %{name: "Cause ends second", end_date: ~D[2019-12-11]})
-    insert(:cause, %{name: "Cause ends third", end_date: ~D[2020-01-01]})
-    insert(:cause, %{name: "Cause ends first", end_date: ~D[2019-12-01]})
+    ten_days_from_now = Timex.add(Timex.now(), Timex.Duration.from_days(10))
+    twenty_days_from_now = Timex.add(Timex.now(), Timex.Duration.from_days(20))
+    thirty_days_from_now = Timex.add(Timex.now(), Timex.Duration.from_days(30))
+    insert(:cause, %{name: "Cause ends in 20 days", end_date: twenty_days_from_now})
+    insert(:cause, %{name: "Cause ends in 30 days", end_date: thirty_days_from_now})
+    insert(:cause, %{name: "Cause ends in 10 days", end_date: ten_days_from_now})
     conn = build_conn()
     conn = post conn, "/api", query: causes_ending_soon_query, variables: %{scope: "ending_soon"}
 
     expected_result = %{
       "data" => %{
         "causes" => [
-          %{"name" => "Cause ends first"},
-          %{"name" => "Cause ends second"},
-          %{"name" => "Cause ends third"}
+          %{"name" => "Cause ends in 10 days"},
+          %{"name" => "Cause ends in 20 days"},
+          %{"name" => "Cause ends in 30 days"}
         ]
       }
     }
@@ -140,17 +144,20 @@ defmodule SingForNeeds.Schema.Query.CauseTest do
       }
     """
 
-    insert(:cause, %{name: "Cause ends third", end_date: ~D[2020-01-01]})
-    insert(:cause, %{name: "Cause ends second", end_date: ~D[2019-12-11]})
-    insert(:cause, %{name: "Cause ends first", end_date: ~D[2018-12-01]})
+    twenty_days_from_now = Timex.add(Timex.now(), Timex.Duration.from_days(20))
+    thirty_days_from_now = Timex.add(Timex.now(), Timex.Duration.from_days(30))
+
+    insert(:cause, %{name: "Cause ends in 30 days", end_date: thirty_days_from_now})
+    insert(:cause, %{name: "Cause ends in 20 days", end_date: twenty_days_from_now})
+    insert(:cause, %{name: "Cause ends in the past", end_date: ~D[2018-12-01]})
     conn = build_conn()
     conn = post conn, "/api", query: causes_ending_soon_query, variables: %{scope: "ending_soon"}
 
     expected_result = %{
       "data" => %{
         "causes" => [
-          %{"name" => "Cause ends second"},
-          %{"name" => "Cause ends third"}
+          %{"name" => "Cause ends in 20 days"},
+          %{"name" => "Cause ends in 30 days"}
         ]
       }
     }

--- a/test/sing_for_needs_web/schema/query/causes_test.exs
+++ b/test/sing_for_needs_web/schema/query/causes_test.exs
@@ -131,4 +131,31 @@ defmodule SingForNeeds.Schema.Query.CauseTest do
 
     assert expected_result == json_response(conn, 200)
   end
+
+  test "causes ending soon filters out causes with past end date" do
+    causes_ending_soon_query = """
+      query($scope: String) {
+          causes(scope: $scope) {
+              name
+          }
+      }
+    """
+
+    insert(:cause, %{name: "Cause ends third", end_date: ~D[2020-01-01]})
+    insert(:cause, %{name: "Cause ends second", end_date: ~D[2019-12-11]})
+    insert(:cause, %{name: "Cause ends first", end_date: ~D[2018-12-01]})
+    conn = build_conn()
+    conn = post conn, "/api", query: causes_ending_soon_query, variables: %{scope: "ending_soon"}
+
+    expected_result = %{
+      "data" => %{
+        "causes" => [
+          %{"name" => "Cause ends second"},
+          %{"name" => "Cause ends third"}
+        ]
+      }
+    }
+
+    assert expected_result == json_response(conn, 200)
+  end
 end


### PR DESCRIPTION
### What does this PR do?
- Adds an argument `scope` in causes query to indicate if we want causes ending soon or trending causes
- Implements Trending causes as causes with highest donations
- Implements Causes ending soon as causes with the nearest end date
- Ensures causes ending soon are causes whose end dates are always in the future
- Add timex library for easier dealing with dates




#### How should this be manually tested?

1. Query for causes ending soon and trending causes in graphiql



#### Any background context you want to provide?
Causes ending soon and trending causes are needed for the front end



#### What are the relevant Github Issues ?
Fixes #112 
Fixes #113 


#### Screenshots (If applicable)


