### PR TITLE
Implement limit and scope variable in same causes query

### DIFF
--- a/lib/sing_for_needs/causes.ex
+++ b/lib/sing_for_needs/causes.ex
@@ -43,26 +43,24 @@ defmodule SingForNeeds.Causes do
     |> Repo.all()
   end
 
-  defp causes_query(%{scope: scope, limit: limit}) do
-    case scope do
-      "trending" ->
-        from(c in Cause,
+  defp causes_query(%{scope: "trending", limit: limit}) do
+     from(c in Cause,
           left_join: a in assoc(c, :artists),
           preload: [:artists],
           order_by: [desc: :amount_raised, desc: count(a.id)],
           group_by: c.id,
           limit: ^limit,
           select: c
-        )
+      )
+  end
 
-      "ending_soon" ->
-        from(c in Cause,
-          where: c.end_date > ^Timex.now(),
-          order_by: [asc: c.end_date],
-          limit: ^limit,
-          select: c
-        )
-    end
+  defp causes_query(%{scope: "ending_soon", limit: limit}) do
+    from(c in Cause,
+      where: c.end_date > ^Timex.now(),
+      order_by: [asc: c.end_date],
+      limit: ^limit,
+      select: c
+    )
   end
 
   defp causes_query(%{limit: limit}) do

--- a/lib/sing_for_needs/causes.ex
+++ b/lib/sing_for_needs/causes.ex
@@ -44,12 +44,13 @@ defmodule SingForNeeds.Causes do
   end
 
   defp causes_query(criteria) do
-    query = from c in Cause, preload: [:artists], select: c
+    query = from c in Cause, select: c
     Enum.reduce(criteria, query, &compose_query/2)
   end
 
   defp compose_query({:scope, "trending"}, query) do
     from c in query,
+      preload: [:artists],
       left_join: a in assoc(c, :artists),
       order_by: [desc: :amount_raised, desc: count(a.id)],
       group_by: c.id
@@ -57,6 +58,7 @@ defmodule SingForNeeds.Causes do
 
   defp compose_query({:scope, "ending_soon"}, query) do
     from c in query,
+      preload: [:artists],
       where: c.end_date > ^Timex.now(),
       order_by: [asc: c.end_date]
   end

--- a/lib/sing_for_needs/causes.ex
+++ b/lib/sing_for_needs/causes.ex
@@ -51,6 +51,7 @@ defmodule SingForNeeds.Causes do
           preload: [:artists],
           order_by: [desc: :amount_raised, desc: count(a.id)],
           group_by: c.id,
+          limit: ^limit,
           select: c
         )
 

--- a/lib/sing_for_needs/causes.ex
+++ b/lib/sing_for_needs/causes.ex
@@ -43,6 +43,27 @@ defmodule SingForNeeds.Causes do
     |> Repo.all()
   end
 
+  defp causes_query(%{scope: scope, limit: limit}) do
+    case scope do
+      "trending" ->
+        from(c in Cause,
+          left_join: a in assoc(c, :artists),
+          preload: [:artists],
+          order_by: [desc: :amount_raised, desc: count(a.id)],
+          group_by: c.id,
+          select: c
+        )
+
+      "ending_soon" ->
+        from(c in Cause,
+          where: c.end_date > ^Timex.now(),
+          order_by: [asc: c.end_date],
+          limit: ^limit,
+          select: c
+        )
+    end
+  end
+
   defp causes_query(%{limit: limit}) do
     limit(Cause, ^limit)
   end

--- a/lib/sing_for_needs/causes.ex
+++ b/lib/sing_for_needs/causes.ex
@@ -57,9 +57,11 @@ defmodule SingForNeeds.Causes do
   end
 
   defp compose_query({:scope, "ending_soon"}, query) do
+    ninety_days_from_now = Timex.add(Timex.now(), Timex.Duration.from_days(90))
+
     from c in query,
       preload: [:artists],
-      where: c.end_date > ^Timex.now(),
+      where: c.end_date > ^Timex.now() and c.end_date <= ^ninety_days_from_now,
       order_by: [asc: c.end_date]
   end
 

--- a/test/sing_for_needs_web/schema/query/causes_test.exs
+++ b/test/sing_for_needs_web/schema/query/causes_test.exs
@@ -63,7 +63,9 @@ defmodule SingForNeeds.Schema.Query.CauseTest do
 
     insert_list(5, :cause)
     conn = build_conn()
-    conn = post conn, "/api", query: causes_limit_query, variables: %{limit: 2}
+
+    conn_after_posting_causes_limit_query =
+      post conn, "/api", query: causes_limit_query, variables: %{limit: 2}
 
     expected_response = %{
       "data" => %{
@@ -74,7 +76,7 @@ defmodule SingForNeeds.Schema.Query.CauseTest do
       }
     }
 
-    response = json_response(conn, 200)
+    response = json_response(conn_after_posting_causes_limit_query, 200)
     assert expected_response == response
   end
 
@@ -89,7 +91,9 @@ defmodule SingForNeeds.Schema.Query.CauseTest do
 
     setup_causes()
     conn = build_conn()
-    conn = post conn, "/api", query: trending_causes_query, variables: %{scope: "trending"}
+
+    conn_after_posting_trending_causes_query =
+      post conn, "/api", query: trending_causes_query, variables: %{scope: "trending"}
 
     expected_response = %{
       "data" => %{
@@ -103,7 +107,7 @@ defmodule SingForNeeds.Schema.Query.CauseTest do
       }
     }
 
-    response = json_response(conn, 200)
+    response = json_response(conn_after_posting_trending_causes_query, 200)
     assert expected_response == response
   end
 
@@ -118,7 +122,9 @@ defmodule SingForNeeds.Schema.Query.CauseTest do
 
     setup_causes()
     conn = build_conn()
-    conn = post conn, "/api", query: causes_ending_soon_query, variables: %{scope: "ending_soon"}
+
+    conn_after_posting_causes_ending_soon_query =
+      post conn, "/api", query: causes_ending_soon_query, variables: %{scope: "ending_soon"}
 
     expected_response = %{
       "data" => %{
@@ -130,7 +136,7 @@ defmodule SingForNeeds.Schema.Query.CauseTest do
       }
     }
 
-    response = json_response(conn, 200)
+    response = json_response(conn_after_posting_causes_ending_soon_query, 200)
     assert expected_response == response
   end
 
@@ -145,7 +151,9 @@ defmodule SingForNeeds.Schema.Query.CauseTest do
 
     setup_causes()
     conn = build_conn()
-    conn = post conn, "/api", query: causes_ending_soon_query, variables: %{scope: "ending_soon"}
+
+    conn_after_posting_causes_ending_soon_query =
+      post conn, "/api", query: causes_ending_soon_query, variables: %{scope: "ending_soon"}
 
     expected_response = %{
       "data" => %{
@@ -157,7 +165,7 @@ defmodule SingForNeeds.Schema.Query.CauseTest do
       }
     }
 
-    response = json_response(conn, 200)
+    response = json_response(conn_after_posting_causes_ending_soon_query, 200)
     assert expected_response == response
   end
 
@@ -175,7 +183,7 @@ defmodule SingForNeeds.Schema.Query.CauseTest do
     insert(:cause, %{name: "Awesome Cause 100", end_date: one_hundred_days_from_now})
     conn = build_conn()
 
-    conn_after_post =
+    conn_after_posting_causes_ending_soon_query =
       post conn, "/api", query: causes_ending_soon_query, variables: %{scope: "ending_soon"}
 
     expected_response = %{
@@ -188,7 +196,7 @@ defmodule SingForNeeds.Schema.Query.CauseTest do
       }
     }
 
-    response = json_response(conn_after_post, 200)
+    response = json_response(conn_after_posting_causes_ending_soon_query, 200)
     assert expected_response == response
   end
 
@@ -204,7 +212,7 @@ defmodule SingForNeeds.Schema.Query.CauseTest do
     setup_causes()
     conn = build_conn()
 
-    conn =
+    conn_after_posting_causes_ending_soon_with_limit_query =
       post conn, "/api",
         query: causes_ending_soon_with_limit_query,
         variables: %{scope: "ending_soon", limit: 2}
@@ -215,7 +223,7 @@ defmodule SingForNeeds.Schema.Query.CauseTest do
       }
     }
 
-    response = json_response(conn, 200)
+    response = json_response(conn_after_posting_causes_ending_soon_with_limit_query, 200)
     assert expected_result == response
   end
 
@@ -231,7 +239,7 @@ defmodule SingForNeeds.Schema.Query.CauseTest do
     setup_causes()
     conn = build_conn()
 
-    conn =
+    conn_after_posting_trending_causes_with_limit_query =
       post conn, "/api",
         query: trending_causes_with_limit_query,
         variables: %{scope: "trending", limit: 3}
@@ -246,7 +254,7 @@ defmodule SingForNeeds.Schema.Query.CauseTest do
       }
     }
 
-    response = json_response(conn, 200)
+    response = json_response(conn_after_posting_trending_causes_with_limit_query, 200)
 
     assert expected_response == response
   end

--- a/test/sing_for_needs_web/schema/query/causes_test.exs
+++ b/test/sing_for_needs_web/schema/query/causes_test.exs
@@ -45,8 +45,8 @@ defmodule SingForNeeds.Schema.Query.CauseTest do
       }
     }
 
-    json_response = json_response(conn, 200)
-    assert expected_response == json_response
+    response = json_response(conn, 200)
+    assert expected_response == response
   end
 
   test "causes query can filter causes with limit" do
@@ -74,8 +74,8 @@ defmodule SingForNeeds.Schema.Query.CauseTest do
       }
     }
 
-    json_response = json_response(conn, 200)
-    assert expected_response == json_response
+    response = json_response(conn, 200)
+    assert expected_response == response
   end
 
   test "trending causes are ordered by most amount donated and number of artists" do
@@ -184,7 +184,8 @@ defmodule SingForNeeds.Schema.Query.CauseTest do
       }
     }
 
-    assert expected_result == json_response(conn, 200)
+    response = json_response(conn, 200)
+    assert expected_result == response
   end
 
   test "scope: trending and limit:2 passed to causes query" do

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -1,5 +1,7 @@
 defmodule SingForNeeds.TestHelpers do
   @moduledoc false
+  use Timex
+  import SingForNeeds.Factory
   alias SingForNeeds.Artists.Artist
   alias SingForNeeds.Causes.Cause
   alias SingForNeeds.Performances.Performance
@@ -71,6 +73,45 @@ defmodule SingForNeeds.TestHelpers do
       |> Repo.insert!()
 
     [cause_1, cause_2]
+  end
+
+  def setup_causes do
+    artists = insert_list(4, :artist)
+    twenty_days_from_now = Timex.add(Timex.now(), Timex.Duration.from_days(20))
+    thirty_days_from_now = Timex.add(Timex.now(), Timex.Duration.from_days(30))
+    fifteen_days_from_now = Timex.add(Timex.now(), Timex.Duration.from_days(15))
+    five_days_ago = Timex.add(Timex.now(), Timex.Duration.from_days(-5))
+    nine_days_ago = Timex.add(Timex.now(), Timex.Duration.from_days(-9))
+
+    insert(:cause, %{
+      name: "Awesome cause 1",
+      end_date: thirty_days_from_now,
+      amount_raised: 30_000,
+      artists: Enum.take(artists, 2),
+      description: Faker.Lorem.paragraph(1)
+    })
+
+    insert(:cause, %{
+      name: "Awesome Cause 2",
+      end_date: twenty_days_from_now,
+      amount_raised: 10_000
+    })
+
+    insert(:cause, %{name: "Awesome Cause 3", end_date: fifteen_days_from_now})
+
+    insert(:cause, %{
+      name: "Awesome cause 4",
+      end_date: five_days_ago,
+      amount_raised: 10_000,
+      artists: Enum.take(artists, -2)
+    })
+
+    insert(:cause, %{
+      name: "Awesome cause 5",
+      end_date: nine_days_ago,
+      amount_raised: 90_000,
+      artists: artists
+    })
   end
 
   def performance_setup do


### PR DESCRIPTION
### What does this PR do?
- Enables the causes query to use both the scope and limit variables together




#### How should this be manually tested?

1. On terminal, run command ...
Play around with this query and variables on you graphiql play ground
```
query($limit: Int, $scope: String){
  causes(limit: $limit, scope: $scope) {
    id
    name
    amountRaised
    endDate
    artists{
      name
    }
  }
}
```

variables
```
{"scope": "ending_soon", "limit": 3}
```

#### What are the relevant Github Issues ?
Fixes #123 
