### PR TITLE
Implement changeset errors helper

### DIFF
--- a/lib/sing_for_needs_web/resolvers/accounts.ex
+++ b/lib/sing_for_needs_web/resolvers/accounts.ex
@@ -3,14 +3,14 @@ defmodule SingForNeedsWeb.Resolvers.Accounts do
   Resolvers for User
   """
   alias SingForNeeds.Accounts
+  alias SingForNeedsWeb.Schema.ChangesetErrors
 
   def signup(_parent, args, _resolution) do
     case Accounts.create_user(args) do
-      {:error, _changeset} ->
+      {:error, changeset} ->
         {
           :error,
-          message: "Could not create account"
-          # details: SingForNeedsWeb.Schema.ChangesetErrors.error_details(changeset)
+          message: "Could not create account", details: ChangesetErrors.error_details(changeset)
         }
 
       {:ok, user} ->

--- a/lib/sing_for_needs_web/schema/changeset_errors.ex
+++ b/lib/sing_for_needs_web/schema/changeset_errors.ex
@@ -1,0 +1,20 @@
+defmodule SingForNeedsWeb.Schema.ChangesetErrors do
+  @moduledoc """
+  Contains a helper function to traverse the changeset for error 
+  messages and return a map
+  """
+
+  @doc """
+  Traverses the changeset errors and returns a map of 
+  error messages. For example:
+
+  %{start_date: ["can't be blank"], end_date: ["can't be blank"]}
+  """
+  def error_details(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+      Enum.reduce(opts, msg, fn {key, value}, acc ->
+        String.replace(acc, "%{#{key}}", to_string(value))
+      end)
+    end)
+  end
+end

--- a/test/sing_for_needs_web/schema/mutation/signup_test.exs
+++ b/test/sing_for_needs_web/schema/mutation/signup_test.exs
@@ -35,4 +35,31 @@ defmodule SingForNeedsWeb.Schema.Mutation.SignupTest do
 
     assert %{"user" => %{"username" => "test"}} == session
   end
+
+  test "signup with invalid args returns error and details" do
+    input = %{
+      username: nil,
+      email: "test@example.com",
+      password: "sec"
+    }
+
+    conn =
+      post(build_conn(), "/api", %{
+        query: @query,
+        variables: input
+      })
+
+    expected_result = %{
+      "errors" => [
+        %{
+          "message" => "Argument \"username\" has invalid value $username."
+        },
+        %{
+          "message" => "Variable \"username\": Expected non-null, found null."
+        }
+      ]
+    }
+
+    assert expected_result = json_response(conn, 200)
+  end
 end


### PR DESCRIPTION

### What does this PR do?

- Traverses changeset and creates a map of errors
- Use the changeset error helper for signup mutation resolver






#### What are the relevant Github Issues ?

Fixes #135 

#### Screenshots (If applicable)


